### PR TITLE
Update postTabInfo.js

### DIFF
--- a/postTabInfo.js
+++ b/postTabInfo.js
@@ -11,7 +11,7 @@ function getSessionId() {
     if (allCookies.indexOf('sid=') == -1) {
       return null;
     }
-    return allCookies.match(/sid\=(.*?);/)[1];
+    return allCookies.match(/sid\=(.*?)(;|$)/)[1];
   }
 }
 


### PR DESCRIPTION
Fix for bug when "sid" cookie is alphabetically the last cookie for your site. In that case it doesn't match and a null exception is thrown instead of opening Workbench as expected. Now filter on semi-colon or EOL. 